### PR TITLE
[Fix] the bug that `.phplint-cache` has been used only once.

### DIFF
--- a/src/Linter.php
+++ b/src/Linter.php
@@ -93,6 +93,8 @@ class Linter
                 if (!isset($this->cache[$filename]) || $this->cache[$filename] !== md5_file($filename)) {
                     $running[$filename] = new Lint(PHP_BINARY.' -l '.$filename);
                     $running[$filename]->start();
+                } else {
+                    $newCache[$filename] = $this->cache[$filename];
                 }
             }
 


### PR DESCRIPTION
之前 $newCache 只有在检测文件后才会加入
于是原本使用 cache 跳过了检测的文件不会被写入 $newCache 中
导致缓存实际上只能使用一次