### PR TITLE
when use -q, output brief result directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 /vendor/
+.idea
 .phplint-cache

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Options:
   -c, --configuration=CONFIGURATION  Read configuration from config file (default: .phplint.yml).
       --no-configuration             Ignore default configuration file (default: .phplint.yml).
       --no-cache                     Ignore cached data.
-  -h, --help                         Display this help message
-  -q, --quiet                        Do not output any message
-  -V, --version                      Display this application version
+  -h, --help                         Display this help message.
+  -q, --quiet                        Quiet model, display result only.
+  -V, --version                      Display this application version.
 ```
 
 example:

--- a/src/Command/LintScreen.php
+++ b/src/Command/LintScreen.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the overtrue/phplint.
+ *
+ * Codes from sebastian\environment
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ */
+
+namespace Overtrue\PHPLint\Command;
+
+/**
+ */
+class LintScreen
+{
+    const STDIN  = 0;
+    const STDOUT = 1;
+    const STDERR = 2;
+
+    /**
+     * Returns true if STDOUT supports colorization.
+     *
+     * This code has been copied and adapted from
+     * Symfony\Component\Console\Output\OutputStream.
+     *
+     * @return bool
+     */
+    public static function hasColorSupport()
+    {
+        if (DIRECTORY_SEPARATOR == '\\') {
+            return false !== getenv('ANSICON') || 'ON' === getenv('ConEmuANSI') || 'xterm' === getenv('TERM');
+        }
+
+        if (!defined('STDOUT')) {
+            return false;
+        }
+
+        return self::isInteractive(STDOUT);
+    }
+
+    /**
+     * Returns the number of columns of the terminal.
+     *
+     * @return int
+     */
+    public static function getNumberOfColumns()
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $columns = 80;
+
+            if (preg_match('/^(\d+)x\d+ \(\d+x(\d+)\)$/', trim(getenv('ANSICON')), $matches)) {
+                $columns = $matches[1];
+            } elseif (function_exists('proc_open')) {
+                $process = proc_open(
+                    'mode CON',
+                    array(
+                        1 => ['pipe', 'w'],
+                        2 => ['pipe', 'w']
+                    ),
+                    $pipes,
+                    null,
+                    null,
+                    ['suppress_errors' => true]
+                );
+
+                if (is_resource($process)) {
+                    $info = stream_get_contents($pipes[1]);
+
+                    fclose($pipes[1]);
+                    fclose($pipes[2]);
+                    proc_close($process);
+
+                    if (preg_match('/--------+\r?\n.+?(\d+)\r?\n.+?(\d+)\r?\n/', $info, $matches)) {
+                        $columns = $matches[2];
+                    }
+                }
+            }
+
+            return $columns - 1;
+        }
+
+        if (!self::isInteractive(self::STDIN)) {
+            return 80;
+        }
+
+        if (function_exists('shell_exec') && preg_match('#\d+ (\d+)#', shell_exec('stty size'), $match) === 1) {
+            if ((int) $match[1] > 0) {
+                return (int) $match[1];
+            }
+        }
+
+        if (function_exists('shell_exec') && preg_match('#columns = (\d+);#', shell_exec('stty'), $match) === 1) {
+            if ((int) $match[1] > 0) {
+                return (int) $match[1];
+            }
+        }
+
+        return 80;
+    }
+
+    /**
+     * Returns if the file descriptor is an interactive terminal or not.
+     *
+     * @param int|resource $fileDescriptor
+     *
+     * @return bool
+     */
+    public static function isInteractive($fileDescriptor = self::STDOUT)
+    {
+        return function_exists('posix_isatty') && @posix_isatty($fileDescriptor);
+    }
+}


### PR DESCRIPTION
如 #8 中讨论的问题

在使用 capistrano 的时候，一行一个点会把部署日志刷好几屏，特别是有项目文件多，又同时部署多台机器的时候。

-q 参数虽然是指定安静模式，但是如果完全没有输出也就没有什么意义了
于是我在这个 PR 中将这个 参数 用了起来
使用 -q 参数的时候，不会打印检测的过程，直接打印结果

无报错时：
![2016-08-20 9 10 00](https://cloud.githubusercontent.com/assets/2182089/17831414/8bc121aa-671a-11e6-857d-0349b5e3e7c6.png)

有报错时：
![2016-08-20 9 09 37](https://cloud.githubusercontent.com/assets/2182089/17831419/950f89c2-671a-11e6-84ce-11f841c94079.png)

顺便修了 getScreenColumns() 这个方法中的一个小问题