### PR TITLE
Removing if condition with undefined variable

### DIFF
--- a/src/Command/LintCommand.php
+++ b/src/Command/LintCommand.php
@@ -354,10 +354,6 @@ class LintCommand extends Command
             return $columns - 1;
         }
 
-        if (!(function_exists('posix_isatty') && @posix_isatty($fileDescriptor))) {
-            return 80;
-        }
-
         if (function_exists('shell_exec') && preg_match('#\d+ (\d+)#', shell_exec('stty size'), $match) === 1) {
             if ((int) $match[1] > 0) {
                 return (int) $match[1];


### PR DESCRIPTION
It was added [here](https://github.com/overtrue/phplint/commit/6035c41450d01b4a5af2a5183d0e6a8ee48d07fc#diff-b00b7dcda108d6349dea295226332191R306) and `$fileDescriptor` was never defined.

It raises a warning:

```
PHP Notice:  Undefined variable: fileDescriptor in /var/www/awesome-application/vendor/overtrue/phplint/src/Command/LintCommand.php on line 357
```

when xdebug is set to scream:
```
xdebug.scream = 1
```