### PR TITLE
Feature: set cache option from configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ You can also define configuration as a file `.phplint.yml`:
 ```yaml
 path: ./
 jobs: 10
+cache: build/phplint.cache
 extensions:
   - php
 exclude:
@@ -103,4 +104,3 @@ $errors = $linter->lint();
 ## License
 
 MIT
-

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Options:
   -c, --configuration=CONFIGURATION  Read configuration from config file (default: ./.phplint.yml).
       --no-configuration             Ignore default configuration file (default: ./.phplint.yml).
       --no-cache                     Ignore cached data.
+      --cache=CACHE                  Path to the cache file.
   -h, --help                         Display this help message
   -q, --quiet                        Do not output any message
   -V, --version                      Display this application version

--- a/src/Command/LintCommand.php
+++ b/src/Command/LintCommand.php
@@ -261,6 +261,7 @@ class LintCommand extends Command
     {
         $options = $this->input->getOptions();
         $options['path'] = $this->input->getArgument('path');
+        $options['cache'] = $this->input->getOption('cache');
 
         $config = [];
 

--- a/src/Command/LintCommand.php
+++ b/src/Command/LintCommand.php
@@ -154,8 +154,8 @@ class LintCommand extends Command
         $linter = new Linter($options['path'], $options['exclude'], $options['extensions']);
         $linter->setProcessLimit($options['jobs']);
 
-        if (null !== $input->getOption('cache')) {
-            Cache::setFilename($input->getOption('cache'));
+        if ($options['cache']) {
+            Cache::setFilename($options['cache']);
         }
 
         $usingCache = 'No';

--- a/src/Process/Lint.php
+++ b/src/Process/Lint.php
@@ -33,7 +33,7 @@ class Lint extends Process
     }
 
     /**
-     * @return bool|string
+     * @return bool|array
      */
     public function getSyntaxError()
     {


### PR DESCRIPTION
Currently you can only set up the cache file option from the command line, this is because the command is using `$input->getOption('cache')` instead of `$options['cache']`.

With this pull request you can set inside `.phplint.yml` the location of the file just as it was set in the command line. The command line `--cache` argument override the `cache` option from configuration file.

I perform the following test on my machine:

| in config | command line | cache file |
|---|---|---|
| - | - | .phplint-cache |
| .cache-config | - | .cache-config |
| - | .cache-cli | .cache-cli |
| .cache-config | .cache-cli | .cache-cli |

Also in this PR:
- Add --cache=CACHE argument to README.md
- Add `cache: build/phplint.cache` as example inside configuration file to README.md
- Fix doc block: `Method Overtrue\PHPLint\Process\Lint::getSyntaxError()` should return `bool|string` but returns `mixed[]`. Thanks to phpstan!

Thanks!