### PR TITLE
Check for non-empty value instead of intrinsic truthy value.

### DIFF
--- a/src/Command/LintCommand.php
+++ b/src/Command/LintCommand.php
@@ -154,7 +154,7 @@ class LintCommand extends Command
         $linter = new Linter($options['path'], $options['exclude'], $options['extensions']);
         $linter->setProcessLimit($options['jobs']);
 
-        if ($options['cache']) {
+        if (!empty($options['cache'])) {
             Cache::setFilename($options['cache']);
         }
 


### PR DESCRIPTION
I am getting the following error when running the CLI command:

```sh
PHP Notice:  Undefined index: cache in /Users/adamplante/projects/project-omega/vendor/overtrue/phplint/src/Command/LintCommand.php on line 157
PHP Stack trace:
PHP   1. {main}() /Users/adamplante/projects/project-omega/vendor/overtrue/phplint/bin/phplint:0
PHP   2. Overtrue\PHPLint\Console\Application->run() /Users/adamplante/projects/project-omega/vendor/overtrue/phplint/bin/phplint:32
PHP   3. Overtrue\PHPLint\Console\Application->doRun() /Users/adamplante/projects/project-omega/vendor/symfony/console/Application.php:143
PHP   4. Overtrue\PHPLint\Console\Application->doRunCommand() /Users/adamplante/projects/project-omega/vendor/symfony/console/Application.php:241
PHP   5. Overtrue\PHPLint\Command\LintCommand->run() /Users/adamplante/projects/project-omega/vendor/symfony/console/Application.php:865
PHP   6. Overtrue\PHPLint\Command\LintCommand->execute() /Users/adamplante/projects/project-omega/vendor/symfony/console/Command/Command.php:252
```

It looks like the error stems from [/src/Command/LintCommand.php:287](https://github.com/overtrue/phplint/blob/master/src/Command/LintCommand.php#L287). The result of the expression on the third parameter (`array_filter($options)`) is removing that index from the returned value.

```php
// array_filter($options) strips out $options['config']
$options = array_merge($this->defaults, array_filter($config), array_filter($options));
```

This commit checks for a non-empty value instead of an intrinsic truthy value. The non-empty value check will cover the scenario when the index `$options['config']` is not set and will behave as expected if $options['config'] contains a truthy value.

If you have a preferred way of submitting a PR, please let me know.