### PR TITLE
Create folder (recursively) for cache file if it does not exists

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -73,6 +73,20 @@ class Cache
     public static function setFilename($filename)
     {
         self::$filename = $filename;
+        self::makeFolderForFilename();
+    }
+
+    /**
+     * Try to create the folder recursively where the cache file is stored.
+     * It depends on current value of static::getFilename().
+     */
+    private static function makeFolderForFilename()
+    {
+        $filename = self::getFilename();
+        $dirname = dirname($filename);
+        if (!file_exists($dirname)) {
+            mkdir($dirname, 0777, true);
+        }
     }
 
     /**


### PR DESCRIPTION
This pull request fixes issue #36 

Current behavior of `\Overtrue\PHPLint\Cache::put` is to show a lot of PHP warnings if cannot I/O on the cache file. The class behave in that way on weird cases like: the config file is actually a directory, is not writable, or write on a full disk...

I'm not going to change that, I think we can figure it out how to handle all this I/O FS operations for the whole class in another conversation. You are only using four static methods: `Cache::setFilename`, `Cache::isCached`, `Cache::get()` & `Cache::put()`

My first idea was modify `put` but that is the most used method. Instead I'm working on `setFilename` that is used only once.

When `\Overtrue\PHPLint\Cache::setFilename($filename)` is called the function will check for the directory name of `$filename` and if it does not exists (as a folder or file or anything) it will try to create that directory recursively.

Tested with calls like:
`bin/phplint --cache=build/phplint.cache`
`bin/phplint --cache=build/caches/.phplint`
`bin/phplint --cache=/dev/null`

To produce an error just try with domething like `bin/phplint --cache=dir/folder/`

BTW: I think a note saying that the cache file is always dependent of the current working directory `getcwd()` is necessary. Or maybe fully refactor `Cache` class.

PS: oh my, this explanation is bigger than the 7 lines patch!
