### PR TITLE
Minimal improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
   ],
   "require": {
     "php": ">=5.5.9",
+    "ext-json": "*",
     "symfony/console": "^3.0|^4.0",
     "symfony/finder": "^3.0|^4.0",
     "symfony/process": "^3.0|^4.0",

--- a/src/Command/LintCommand.php
+++ b/src/Command/LintCommand.php
@@ -139,7 +139,7 @@ class LintCommand extends Command
      * @param InputInterface  $input  An InputInterface instance
      * @param OutputInterface $output An OutputInterface instance
      *
-     * @throws LogicException When this abstract method is not implemented
+     * @throws \LogicException When this abstract method is not implemented
      *
      * @return null|int null or 0 if everything went fine, or an error code
      *

--- a/src/Command/LintCommand.php
+++ b/src/Command/LintCommand.php
@@ -420,6 +420,8 @@ class LintCommand extends Command
             return $configuration;
         } catch (ParseException $e) {
             $this->output->writeln(sprintf('<error>Unable to parse the YAML string: %s</error>', $e->getMessage()));
+
+            return [];
         }
     }
 }

--- a/src/Command/LintCommand.php
+++ b/src/Command/LintCommand.php
@@ -205,7 +205,7 @@ class LintCommand extends Command
         }
 
         if (!empty($options['json'])) {
-            $this->dumpResult($options['json'], $errors, $options, [
+            $this->dumpResult((string) $options['json'], $errors, $options, [
                 'time_usage' => $timeUsage,
                 'memory_usage' => $memUsage,
                 'using_cache' => 'Yes' == $usingCache,
@@ -230,7 +230,7 @@ class LintCommand extends Command
             'errors' => $errors,
         ];
 
-        \file_put_contents((string) $path, \json_encode(\array_merge($result, $context)));
+        \file_put_contents($path, \json_encode(\array_merge($result, $context)));
     }
 
     /**

--- a/src/Linter.php
+++ b/src/Linter.php
@@ -27,7 +27,7 @@ class Linter
     private $processCallback;
 
     /**
-     * @var array
+     * @var SplFileInfo[]
      */
     private $files = [];
 
@@ -73,8 +73,8 @@ class Linter
     /**
      * Check the files.
      *
-     * @param array $files
-     * @param bool  $cache
+     * @param SplFileInfo[] $files
+     * @param bool          $cache
      *
      * @return array
      */
@@ -95,7 +95,7 @@ class Linter
         while (!empty($files) || !empty($running)) {
             for ($i = count($running); !empty($files) && $i < $this->processLimit; ++$i) {
                 $file = array_shift($files);
-                $filename = $file->getRealpath();
+                $filename = $file->getRealPath();
 
                 if (!isset($this->cache[$filename]) || $this->cache[$filename] !== md5_file($filename)) {
                     $lint = new Lint(escapeshellcmd($phpbin).' -d error_reporting=E_ALL -d display_errors=On -l '.escapeshellarg($filename));
@@ -149,7 +149,7 @@ class Linter
     /**
      * Fetch files.
      *
-     * @return array
+     * @return SplFileInfo[]
      */
     public function getFiles()
     {
@@ -171,7 +171,7 @@ class Linter
      *
      * @param string $dir
      *
-     * @return array
+     * @return SplFileInfo[]
      */
     protected function getFilesFromDir($dir)
     {
@@ -192,7 +192,7 @@ class Linter
     /**
      * Set Files.
      *
-     * @param array $files
+     * @param string[] $files
      *
      * @return \Overtrue\PHPLint\Linter
      */

--- a/src/Linter.php
+++ b/src/Linter.php
@@ -13,8 +13,8 @@ namespace Overtrue\PHPLint;
 
 use InvalidArgumentException;
 use Overtrue\PHPLint\Process\Lint;
-use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * Class Linter.

--- a/src/Linter.php
+++ b/src/Linter.php
@@ -98,7 +98,7 @@ class Linter
                 $filename = $file->getRealpath();
 
                 if (!isset($this->cache[$filename]) || $this->cache[$filename] !== md5_file($filename)) {
-                    $lint = new Lint($phpbin.' -d error_reporting=E_ALL -d display_errors=On -l '.escapeshellarg($filename));
+                    $lint = new Lint(escapeshellcmd($phpbin).' -d error_reporting=E_ALL -d display_errors=On -l '.escapeshellarg($filename));
                     $running[$filename] = [
                         'process' => $lint,
                         'file' => $file,

--- a/src/Linter.php
+++ b/src/Linter.php
@@ -84,8 +84,7 @@ class Linter
             $files = $this->getFiles();
         }
 
-        $processCallback = is_callable($this->processCallback) ? $this->processCallback : function () {
-        };
+        $processCallback = is_callable($this->processCallback) ? $this->processCallback : function () {};
 
         $errors = [];
         $running = [];

--- a/src/Linter.php
+++ b/src/Linter.php
@@ -37,7 +37,7 @@ class Linter
     private $cache = [];
 
     /**
-     * @var string|array
+     * @var array
      */
     private $path;
 
@@ -65,7 +65,7 @@ class Linter
      */
     public function __construct($path, array $excludes = [], array $extensions = ['php'])
     {
-        $this->path = $path;
+        $this->path = (array) $path;
         $this->excludes = $excludes;
         $this->extensions = $extensions;
     }
@@ -154,7 +154,7 @@ class Linter
     public function getFiles()
     {
         if (empty($this->files)) {
-            foreach ((array) $this->path as $path) {
+            foreach ($this->path as $path) {
                 if (is_dir($path)) {
                     $this->files = array_merge($this->files, $this->getFilesFromDir($path));
                 } elseif (is_file($path)) {


### PR DESCRIPTION
This pull request contains some improvements found using `php-cs-fixer`, `phpstan`, PhpStorm inspections and `composer-require-checker`.

The only two important commits (imho) are:
- [escape path for php executable, it could contains spaces or quotes ](https://github.com/overtrue/phplint/commit/8b93007177a567e87960d69c872b73cad1b5e8ff).
As both variables `PHP_BINDIR` & `PHP_BINARY` are part of reserved constants I don't think they can be poisoned, in that case the security risk of command line injection is none. The real issue here could be a failed execution.
- [`loadConfiguration` returns `null` if `ParseException` is thown](https://github.com/overtrue/phplint/commit/06f8acd01ef38974803068abf37d385e4ca68e1d)

Feel free to cherry peek or reject.

As always, thanks for your work and project.