### PR TITLE
Make symfony/console 3.2.0 minimal requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "php": ">=5.5.9",
     "ext-json": "*",
-    "symfony/console": "^3.0|^4.0",
+    "symfony/console": "^3.2|^4.0",
     "symfony/finder": "^3.0|^4.0",
     "symfony/process": "^3.0|^4.0",
     "symfony/yaml": "^3.0|^4.0"


### PR DESCRIPTION
The `Symfony\Component\Console\Terminal` class is not available before 3.2.0. This breaks the [builds](https://travis-ci.org/tuupola/ulid/jobs/372634012#L608
) using `--prefer-lowest` switch.  This can also be tested locally from phplint source tree with:

```php
$ composer update --prefer-lowest
$ bin/phplint

 PHP Fatal error:  Uncaught Error: Class 'Symfony\Component\Console\Terminal' not found in /xxx/phplint/src/Command/LintCommand.php:249
```

Setting to `symfony/console` minimum requirement to `^3.2` seems to fix the problem.