### PR TITLE
Use relative file path as the cache key

### DIFF
--- a/src/Linter.php
+++ b/src/Linter.php
@@ -96,16 +96,16 @@ class Linter
             for ($i = count($running); !empty($files) && $i < $this->processLimit; ++$i) {
                 $file = array_shift($files);
                 $filename = $file->getRealPath();
-
-                if (!isset($this->cache[$filename]) || $this->cache[$filename] !== md5_file($filename)) {
+                $key = $file->getRelativePathname();
+                if (!isset($this->cache[$key]) || $this->cache[$key] !== md5_file($filename)) {
                     $lint = new Lint(escapeshellcmd($phpbin).' -d error_reporting=E_ALL -d display_errors=On -l '.escapeshellarg($filename));
-                    $running[$filename] = [
+                    $running[$key] = [
                         'process' => $lint,
                         'file' => $file,
                     ];
                     $lint->start();
                 } else {
-                    $newCache[$filename] = $this->cache[$filename];
+                    $newCache[$key] = $this->cache[$key];
                 }
             }
 


### PR DESCRIPTION
When we use phpcensor|phpci systems there is no ability to use cache feature. 
CI systems create a new temporary directory and build the project. For example 
first commit `/tests/build/24854`
second commit `/tests/build/24855`
File path stored in the cache has a full path. So it is invalid on each build.

p.s. PhpCsFixer uses a relative path to store caches. 
