### PR TITLE
fixing Symfony console error: Passing a command as string when creati…

### DIFF
--- a/src/Linter.php
+++ b/src/Linter.php
@@ -98,7 +98,7 @@ class Linter
                 $filename = $file->getRealPath();
                 $relativePathname = $file->getRelativePathname();
                 if (!isset($this->cache[$relativePathname]) || $this->cache[$relativePathname] !== md5_file($filename)) {
-                    $lint = new Lint(escapeshellcmd($phpbin).' -d error_reporting=E_ALL -d display_errors=On -l '.escapeshellarg($filename));
+                    $lint = Lint::fromShellCommandline(escapeshellcmd($phpbin).' -d error_reporting=E_ALL -d display_errors=On -l '.escapeshellarg($filename));
                     $running[$filename] = [
                         'process' => $lint,
                         'file' => $file,


### PR DESCRIPTION
fixing Symfony console error: Passing a command as string when creating a "Symfony\Component\Process\Process" instance is deprecated since Symfony 4.2, pass it as an array of its arguments instead, or use the "Process::fromShellCommandline()" constructor if you need features provided by the shell.

on line 147
in file  vendor/symfony/process/Process.php