### PR TITLE
Add file_name to errors details

### DIFF
--- a/src/Linter.php
+++ b/src/Linter.php
@@ -119,7 +119,7 @@ class Linter
                 unset($running[$filename]);
                 if ($lint->hasSyntaxError()) {
                     $processCallback('error', $item['file']);
-                    $errors[$filename] = array_merge(['file' => $filename], $lint->getSyntaxError());
+                    $errors[$filename] = array_merge(['file' => $filename, 'file_name' => $relativePathname], $lint->getSyntaxError());
                 } else {
                     $newCache[$item['relativePath']] = md5_file($filename);
                     $processCallback('ok', $item['file']);


### PR DESCRIPTION
This PR aims to resolve https://github.com/overtrue/phplint/issues/63 by adding the `file_name` key to the error's details.