### PR TITLE
JUnit XML output support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 /vendor/
 .phplint-cache
 .php_cs.cache
+.idea

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Options:
       --no-cache                     Ignore cached data.
       --cache=CACHE                  Path to the cache file.
       --json[=JSON]                  Output JSON results to a file.
+      --xml[=XML]                    Output JUnit XML results to a file.
   -h, --help                         Display this help message
   -q, --quiet                        Do not output any message
   -V, --version                      Display this application version

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "symfony/console": "^3.2|^4.0|^5.0",
     "symfony/finder": "^3.0|^4.0|^5.0",
     "symfony/process": "^3.0|^4.0|^5.0",
-    "symfony/yaml": "^3.0|^4.0|^5.0"
+    "symfony/yaml": "^3.0|^4.0|^5.0",
+    "n98/junit-xml": "1.0.0"
   },
   "require-dev": {
     "jakub-onderka/php-console-highlighter": "^0.3.2 || ^0.4"


### PR DESCRIPTION
Added support for standard JUnit XML reports to be able to use this tool in standard CI/CD environments, and to be able to extract/use the reports easily.

Closes #67 