### PR TITLE
Add building official Dockerhub image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,19 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 before_script:
   - composer self-update
   - composer install --prefer-source --no-interaction --dev
 
 script: ./bin/phplint ./ --no-cache
+
 matrix:
   fast_finish: true
+
+deploy:
+  provider: script
+  script: bash docker_push.sh
+  on:
+    branch: master

--- a/README.md
+++ b/README.md
@@ -12,8 +12,16 @@
 
 ## Installation
 
+### Locally, if you have PHP
+
 ```shell
 $ composer require overtrue/phplint --dev -vvv
+```
+
+### Locally, if you only have Docker
+
+```
+docker pull overtrue/phplint:latest
 ```
 
 ## Usage
@@ -110,6 +118,13 @@ uses: overtrue/phplint@master
 with:
   path: .
   options: --exclude=*.log
+```
+
+### Other CI/CD (f.e. Bitbucket Pipelines, GitLab CI)
+
+Run this command using `overtrue/phplint:latest` Docker image:
+```
+/root/.composer/vendor/bin/phplint ./ --exclude=vendor
 ```
 
 ## PHP 扩展包开发

--- a/docker_push.sh
+++ b/docker_push.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+docker push overtrue/phplint


### PR DESCRIPTION
Hi!

Thanks for your great tool!

As I wanted to use it in a CI/CD based on Docker so I had to build and push an image to some registry. It's here https://hub.docker.com/r/gdubicki/overtrue-phplint .

However I would prefer to switch to an image built from your repo, under your name - hence the PR.

Apart from merging this PR you would have to just add your Dockerhub credentials to Travis secrets like documented here https://docs.travis-ci.com/user/docker/#pushing-a-docker-image-to-a-registry .