### PR TITLE
Change minimal symfony/process version to 3.3 (fixes #61)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "ext-json": "*",
     "symfony/console": "^3.2|^4.0|^5.0",
     "symfony/finder": "^3.0|^4.0|^5.0",
-    "symfony/process": "^3.0|^4.0|^5.0",
+    "symfony/process": "^3.3|^4.0|^5.0",
     "symfony/yaml": "^3.0|^4.0|^5.0",
     "n98/junit-xml": "1.0.0"
   },


### PR DESCRIPTION
When running ci with `$ composer install -prefer-lowest` phplint currently fails with PHP 7.1, 7.2 and 7.3.

```
Warning: proc_open() expects parameter 1 to be string, array given in
/home/travis/build/tuupola/example/vendor/symfony/process/Process.php on line 310
```

This PR fixes the problem by bumping the minimal required version of `symfony/process` to 3.3.