### PR TITLE
Use multistage build to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,10 @@
 ARG VERSION=7.3
-FROM php:${VERSION}-cli
 
-RUN set -xe \
-    && apt-get update \
-    && apt-get install -y git unzip \
-    && rm -rf /var/lib/apt/lists/* \
-    # Install composer
-    && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-    && php composer-setup.php --install-dir /usr/local/bin --filename composer \
-    && php -r "unlink('composer-setup.php');" \
-    # Copy default php.ini
-    && cp /usr/local/etc/php/php.ini-development /usr/local/etc/php/php.ini \
-    && composer global require overtrue/phplint
+FROM composer:1.10 AS build
+RUN composer global require overtrue/phplint
+
+FROM php:${VERSION}-cli
+COPY --from=build /tmp/vendor /root/.composer/vendor
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,8 @@ RUN composer global require overtrue/phplint
 
 FROM php:${VERSION}-cli
 COPY --from=build /tmp/vendor /root/.composer/vendor
-
 COPY entrypoint.sh /entrypoint.sh
-
 RUN chmod +x /entrypoint.sh
+RUN cp /usr/local/etc/php/php.ini-development /usr/local/etc/php/php.ini
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
The docker image is 487 MB (170 MB compressed). With a multistage build the size can be reduced to 400 MB (138 MB compressed).