### PR TITLE
Use alpine linux to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG VERSION=7.3
 FROM composer:1.10 AS build
 RUN composer global require overtrue/phplint
 
-FROM php:${VERSION}-cli
+FROM php:${VERSION}-cli-alpine
 COPY --from=build /tmp/vendor /root/.composer/vendor
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,10 @@
 ARG VERSION=7.3
-FROM php:${VERSION}-cli
 
-RUN set -xe \
-    && apt-get update \
-    && apt-get install -y git unzip \
-    && rm -rf /var/lib/apt/lists/* \
-    # Install composer
-    && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-    && php composer-setup.php --install-dir /usr/local/bin --filename composer \
-    && php -r "unlink('composer-setup.php');" \
-    # Copy default php.ini
-    && cp /usr/local/etc/php/php.ini-development /usr/local/etc/php/php.ini \
-    && composer global require overtrue/phplint
+FROM composer:1.10 AS build
+RUN composer global require overtrue/phplint
+
+FROM php:${VERSION}-cli
+COPY --from=build /tmp/vendor /root/.composer/vendor
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,8 @@ RUN composer global require overtrue/phplint
 
 FROM php:${VERSION}-cli
 COPY --from=build /tmp/vendor /root/.composer/vendor
-
 COPY entrypoint.sh /entrypoint.sh
-
 RUN chmod +x /entrypoint.sh
+RUN cp /usr/local/etc/php/php.ini-development /usr/local/etc/php/php.ini
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
After [Use multistage build to reduce image size](#81) the image size can be reduced from 400 MB (138 MB compressed) to 76 MB (30 MB compressed) with Alpine linux