### PR TITLE
Allow to lint for deprecations and notices as well

### DIFF
--- a/src/Linter.php
+++ b/src/Linter.php
@@ -131,9 +131,9 @@ class Linter
                 if ($lint->hasSyntaxError()) {
                     $processCallback('error', $item['file']);
                     $errors[$filename] = array_merge(['file' => $filename, 'file_name' => $item['relativePath']], $lint->getSyntaxError());
-                } elseif ($this->warning && $lint->hasSyntaxWarning()) {
+                } elseif ($this->warning && $lint->hasSyntaxIssue()) {
                     $processCallback('warning', $item['file']);
-                    $errors[$filename] = array_merge(['file' => $filename, 'file_name' => $item['relativePath']], $lint->getSyntaxWarning());
+                    $errors[$filename] = array_merge(['file' => $filename, 'file_name' => $item['relativePath']], $lint->getSyntaxIssue());
                 } else {
                     $newCache[$item['relativePath']] = md5_file($filename);
                     $processCallback('ok', $item['file']);

--- a/src/Process/Lint.php
+++ b/src/Process/Lint.php
@@ -72,7 +72,7 @@ class Lint extends Process
     /**
      * @return bool
      */
-    public function hasSyntaxWarning()
+    public function hasSyntaxIssue()
     {
         $output = trim($this->getOutput());
 
@@ -81,18 +81,18 @@ class Lint extends Process
         }
 
 
-        return false !== strpos($output, 'Warning: ');
+        return (bool)preg_match('/(Warning:|Deprecated:|Notice:)/', $output);
     }
 
     /**
      * @return bool|array
      */
-    public function getSyntaxWarning()
+    public function getSyntaxIssue()
     {
-        if ($this->hasSyntaxWarning()) {
+        if ($this->hasSyntaxIssue()) {
             $out = explode("\n", trim($this->getOutput()));
 
-            return $this->parseWarning(array_shift($out));
+            return $this->parseIssue(array_shift($out));
         }
 
         return false;
@@ -105,9 +105,9 @@ class Lint extends Process
      *
      * @return array
      */
-    public function parseWarning($message)
+    private function parseIssue($message)
     {
-        $pattern = '/^(PHP\s+)?Warning:\s*\s*?(?<error>.+?)\s+in\s+.+?\s*line\s+(?<line>\d+)/';
+        $pattern = '/^(PHP\s+)?(Warning|Deprecated|Notice):\s*?(?<error>.+?)\s+in\s+.+?\s*line\s+(?<line>\d+)/';
 
         $matched = preg_match($pattern, $message, $match);
 


### PR DESCRIPTION
This PR makes linting with `warning`  on also find notices and deprecations. 

This could be considered a BC break as the `warning` flag now finds more issues than previously. 