### PR TITLE
Allow to silenty fail when --quiet/-q option is used (for use in CI)

### DIFF
--- a/src/Command/LintCommand.php
+++ b/src/Command/LintCommand.php
@@ -28,7 +28,6 @@ use Symfony\Component\Console\Terminal;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
-use function array_key_exists;
 
 /**
  * Class LintCommand.

--- a/src/Command/LintCommand.php
+++ b/src/Command/LintCommand.php
@@ -28,6 +28,7 @@ use Symfony\Component\Console\Terminal;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
+use function array_key_exists;
 
 /**
  * Class LintCommand.
@@ -224,7 +225,10 @@ class LintCommand extends Command
             $output->writeln('<error>FAILURES!</error>');
             $output->writeln("<error>Files: {$fileCount}, Failures: {$errCount}</error>");
             $this->showErrors($errors);
-            $code = 1;
+
+            if (! array_key_exists('quiet', $options)) {
+                $code = 1;
+            }
         } else {
             $output->writeln("<info>OK! (Files: {$fileCount}, Success: {$fileCount})</info>");
         }

--- a/src/Command/LintCommand.php
+++ b/src/Command/LintCommand.php
@@ -133,7 +133,13 @@ class LintCommand extends Command
                 'warning',
                 'w',
                 InputOption::VALUE_NONE,
-                'Also show warnings'
+                'Also show warnings.'
+            )
+            ->addOption(
+                'quiet',
+                'q',
+                InputOption::VALUE_NONE,
+                'Allow to silenty fail.'
             );
     }
 
@@ -226,7 +232,7 @@ class LintCommand extends Command
             $output->writeln("<error>Files: {$fileCount}, Failures: {$errCount}</error>");
             $this->showErrors($errors);
 
-            if (! array_key_exists('quiet', $options)) {
+            if (empty($options['quiet'])) {
                 $code = 1;
             }
         } else {


### PR DESCRIPTION
Hi there!

When using PHPLint in GitLab CI/CD without these changes it'll always fail to complete when ignoring the `allow_failure` flag in `.gitlab-ci.yml`.

Is it at all a good idea to only set the failure code when we're not in quiet mode?


Thanks


Tom


Edit: even when allowing failure(s) in GitLab CI/CD it'll fail to process.

Edit 2: happy to report that my fork, installed via Composer, successfully works in GitLab CI/CD.