### PR TITLE
Fix passing arguments and options on Docker image for PHP 7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,5 @@ COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 RUN cp /usr/local/etc/php/php.ini-development /usr/local/etc/php/php.ini
 
+WORKDIR /workdir
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If you want to disable the config file, you can add option `--no-configuration`.
 ### Docker cli
 
 ```bash
-$ docker run overtrue/phplint ./  --exclude=vendor
+docker run --rm -t -v "${PWD}":/workdir overtrue/phplint ./  --exclude=vendor
 ```
 
 ### Program

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -l
 
-set -xe
+set -e
 
-/root/.composer/vendor/bin/phplint ${INPUT_PATH} ${INPUT_OPTIONS}
+exec /root/.composer/vendor/bin/phplint "$@"


### PR DESCRIPTION
As you seems to have not time to do it, here is the same fix I've applied for PHP 8.0, see issue #106 

Fix also the README.md file for Docker cli usage