### PR TITLE
Update Cache.php

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -138,6 +138,6 @@ final class Cache
 
     private function getKey(string $filename): string
     {
-        return str_replace('/', '_', $filename);
+        return str_replace(['{', '}', '(', ')', '/', '\\', '@', ':'], '_', $filename);
     }
 }


### PR DESCRIPTION
fixes Cache key contains reserved characters "{}()/\@:". on Windows-machines, see #176