### PR TITLE
Don't prune cache for unlimited TTL invocations

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -42,8 +42,9 @@ final class Cache
     private AdapterInterface $adapter;
     private int $hits = 0;
     private int $misses = 0;
+    private ?int $cacheLifetime;
 
-    public function __construct(string|object|null $cachePoolAdapter = null)
+    public function __construct(string|object|null $cachePoolAdapter = null, ?int $cacheLifetime = null)
     {
         if (null === $cachePoolAdapter) {
             $adapter = new ArrayAdapter();
@@ -72,6 +73,7 @@ final class Cache
 
         $this->adapter = $adapter;
         $this->pool = $this->createCachePool($adapter);
+        $this->cacheLifetime = $cacheLifetime;
     }
 
     public function createCachePool(AdapterInterface $adapter): CacheItemPoolInterface
@@ -161,6 +163,10 @@ final class Cache
      */
     public function prune(): bool
     {
+        if ($this->cacheLifetime === null || $this->cacheLifetime === 0) {
+            return true;
+        }
+
         return $this->pool instanceof PruneableInterface && $this->pool->prune();
     }
 }

--- a/src/Linter.php
+++ b/src/Linter.php
@@ -72,13 +72,14 @@ final class Linter
         $this->memoryLimit = (string) $configResolver->getOption(OptionDefinition::OPTION_MEMORY_LIMIT);
         $this->warning = $configResolver->getOption(OptionDefinition::WARNING);
 
+        $cacheLifetime = null;
         if ($configResolver->getOption(OptionDefinition::NO_CACHE)) {
             $adapter = new NullAdapter();
         } else {
-            $defaultLifetime = max(0, $configResolver->getOption(OptionDefinition::CACHE_TTL));
-            $adapter = new FilesystemAdapter('paths', $defaultLifetime, $configResolver->getOption(OptionDefinition::CACHE));
+            $cacheLifetime = max(0, $configResolver->getOption(OptionDefinition::CACHE_TTL));
+            $adapter = new FilesystemAdapter('paths', $cacheLifetime, $configResolver->getOption(OptionDefinition::CACHE));
         }
-        $this->cache = new Cache($adapter);
+        $this->cache = new Cache($adapter, $cacheLifetime);
 
         $this->results = [
             'errors' => [],


### PR DESCRIPTION
we should not scan thru the filesystem and try to check files, when the TTL already told us that items will never expire

refs https://github.com/overtrue/phplint/issues/218