### PR TITLE
dependencies: allow symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,13 @@
     "ext-json": "*",
     "ext-mbstring": "*",
     "composer-runtime-api": "^2.0",
-    "symfony/cache": "^6.4 || ^7.0",
-    "symfony/console": "^6.4 || ^7.0",
-    "symfony/event-dispatcher": "^6.4 || ^7.0",
-    "symfony/finder": "^6.4 || ^7.0",
-    "symfony/options-resolver": "^6.4 || ^7.0",
-    "symfony/process": "^6.4 || ^7.0",
-    "symfony/yaml": "^6.4 || ^7.0"
+    "symfony/cache": "^6.4 || ^7.0 || ^8.0",
+    "symfony/console": "^6.4 || ^7.0 || ^8.0",
+    "symfony/event-dispatcher": "^6.4 || ^7.0 || ^8.0",
+    "symfony/finder": "^6.4 || ^7.0 || ^8.0",
+    "symfony/options-resolver": "^6.4 || ^7.0 || ^8.0",
+    "symfony/process": "^6.4 || ^7.0 || ^8.0",
+    "symfony/yaml": "^6.4 || ^7.0 || ^8.0"
   },
   "require-dev": {
     "php-parallel-lint/php-console-highlighter": "^1.0",


### PR DESCRIPTION
Symfony 8 is soon to be released (https://symfony.com/releases/8.0)
8.0.0 RC3 was released 5 days ago.

I've added `^8.0` as an allowed version for symfony dependencies on this project.
I kept 6.4 as it's still an LTS version (https://symfony.com/releases/6.4 end of bug fix November 2026), but 7.4 should be the next one to target when it's released.

