### PR TITLE
Reuse cache entries for identical file contents

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -25,6 +25,7 @@ use Symfony\Contracts\Cache\ItemInterface;
 
 use function class_exists;
 use function get_debug_type;
+use function is_readable;
 use function is_string;
 use function md5_file;
 use function sprintf;
@@ -113,15 +114,16 @@ final class Cache
      */
     public function isHit(string $filename): bool
     {
+        $currentFingerprint = $this->getFingerprint($filename);
+
         // Try to fetch item from cache
-        $item = $this->getItem($filename);
+        $item = $this->pool->getItem($this->getKey($filename, $currentFingerprint));
         if (!$item->isHit()) {
             ++$this->misses;
             return false;
         }
 
         $fingerprintSaved = $item->get();
-        $currentFingerprint = md5_file($filename);
 
         if ($currentFingerprint !== $fingerprintSaved) {
             ++$this->misses;
@@ -151,9 +153,25 @@ final class Cache
         ];
     }
 
-    private function getKey(string $filename): string
+    private function getKey(string $filename, ?string $fingerprint = null): string
     {
+        $fingerprint ??= $this->getFingerprint($filename);
+        if (null !== $fingerprint) {
+            return $fingerprint;
+        }
+
         return str_replace(str_split(ItemInterface::RESERVED_CHARACTERS), '_', $filename);
+    }
+
+    private function getFingerprint(string $filename): ?string
+    {
+        if (!is_readable($filename)) {
+            return null;
+        }
+
+        $fingerprint = md5_file($filename);
+
+        return is_string($fingerprint) ? $fingerprint : null;
     }
 
     /**

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use Symfony\Component\Cache\CacheItem;
 
 use function dirname;
+use function is_readable;
 use function md5_file;
 use function sha1_file;
 use function str_replace;
@@ -141,10 +142,32 @@ final class CacheTest extends TestCase
         $this->assertEquals($fingerprint, self::$cache->getItem($filename)->get());
     }
 
+    public function testSameContentsShareCacheItem(): void
+    {
+        $firstFilename = __DIR__ . '/Fixtures/releases/3118/test.fixture';
+        $secondFilename = __DIR__ . '/Fixtures/releases/3119/test.fixture';
+        $fingerprint = md5_file($firstFilename);
+
+        $firstCacheItem = self::$cache->getItem($firstFilename);
+        $secondCacheItem = self::$cache->getItem($secondFilename);
+
+        $this->assertSame($firstCacheItem->getKey(), $secondCacheItem->getKey());
+
+        $firstCacheItem->set($fingerprint);
+        $saved = self::$cache->saveItem($firstCacheItem);
+
+        $this->assertTrue($saved);
+        $this->assertTrue(self::$cache->isHit($secondFilename));
+    }
+
     private function generateItems(array $values): Generator
     {
         foreach ($values as $filename => $processor) {
-            $key = str_replace('/', '_', $filename);
+            if (is_readable($filename)) {
+                $key = md5_file($filename);
+            } else {
+                $key = str_replace('/', '_', $filename);
+            }
             $value = $processor ? $processor($filename) : null;
             $isHit = (null !== $value);
             yield $key => (self::$createCacheItem)($key, $value, $isHit);

--- a/tests/Cache/Fixtures/releases/3118/test.fixture
+++ b/tests/Cache/Fixtures/releases/3118/test.fixture
@@ -1,0 +1,1 @@
+same release contents

--- a/tests/Cache/Fixtures/releases/3119/test.fixture
+++ b/tests/Cache/Fixtures/releases/3119/test.fixture
@@ -1,0 +1,1 @@
+same release contents


### PR DESCRIPTION
Fixes #224.

This changes readable file cache keys to use the file fingerprint instead of the path-derived key, so identical files copied into separate release directories can share the same cache entry. The existing sanitized path key remains as the fallback for unreadable or unknown paths.

Tests:
- `docker run --rm -v "$PWD:/app" -w /app composer:2 vendor/bin/phpunit --no-progress --testdox --do-not-cache-result --testsuite cache`
- `docker run --rm -v "$PWD:/app" -w /app composer:2 vendor/bin/phpunit --no-progress --testdox --do-not-cache-result`
- `git diff --check`